### PR TITLE
Rails 4.0.0 Support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     nav_lynx (1.0.0)
-      rails (~> 3.2.13)
+      rails (>= 3.2.13)
 
 GEM
   remote: http://rubygems.org/

--- a/nav_lynx.gemspec
+++ b/nav_lynx.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", "~> 3.2.13"
+  s.add_dependency "rails", ">= 3.2.13"
   # s.add_dependency "jquery-rails"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Changed Rails dependency to allow for Rails 4.0.0 and updated Gemfile.lock
