### PR TITLE
Fix: NavLinkHelper::LinkGenerator#current_controller breaks on non-GET current routes

### DIFF
--- a/app/helpers/nav_link_helper.rb
+++ b/app/helpers/nav_link_helper.rb
@@ -53,7 +53,11 @@ module NavLinkHelper
     end
 
     def current_controller
-      controller_for(@request.path)
+      if @request.method.to_s.upcase == "GET"
+        controller_for(@request.path)
+      else
+        Rails.application.routes.recognize_path(@request.path, :method => @request.method)[:controller]
+      end
     end
 
     def segment_for(controller, path)

--- a/spec/helpers/nav_link_helper_spec.rb
+++ b/spec/helpers/nav_link_helper_spec.rb
@@ -50,6 +50,11 @@ describe NavLinkHelper do
         subject.new(request, 'Hi', '/projects').to_html.should == '<a href="/projects" class="selected">Hi</a>'
       end
 
+      it "flags the link as current if the request method is POST instead of the default (GET)" do
+        request.stub(:fullpath => '/projects', :method => "POST")
+        subject.new(request, 'Hi', '/projects').to_html.should == '<a href="/projects" class="selected">Hi</a>'
+      end
+
       it "does not flag the link as current if there are parameters in the path" do
         request.stub(:fullpath).and_return('/projects?all=true')
         subject.new(request, 'Hi', '/projects').to_html.should == '<a href="/projects">Hi</a>'
@@ -77,7 +82,7 @@ describe NavLinkHelper do
           .should == '<li class="container"><a href="/projects">Hi</a></li>'
       end
 
-      it "provides a class for the wrapper when specified along with a selected class if neeeded" do
+      it "provides a class for the wrapper when specified along with a selected class if needed" do
         request.stub(:fullpath).and_return('/projects')
         subject.new(request, 'Hi', '/projects', {}, :wrapper => 'li', :wrapper_class => 'container').to_html
           .should == '<li class="selected container"><a href="/projects">Hi</a></li>'


### PR DESCRIPTION
I have a POST action (in a Devise controller) that should render validation errors on an invalid POST.
However nav_lynx appears to fail at recognizing the current path. It appears that NavLinkHelper::LinkGenerator#current_controller ignores the request method, which means that +Rails.application.routes.recognize_path+ is unaware of the request method and therefore does not recognize the path.

```
nav_link_to root_path, {}, controller_segment: 1
```

Exception with backtrace:
No route matches [GET] "/users/password"

```
actionpack (4.0.0) lib/action_dispatch/routing/route_set.rb:695:in `recognize_path'
~/.rvm/gems/ruby-2.0.0-p247/bundler/gems/nav_lynx-00ae77191c47/app/helpers/nav_link_helper.rb:116:in `controller_for'
~/.rvm/gems/ruby-2.0.0-p247/bundler/gems/nav_lynx-00ae77191c47/app/helpers/nav_link_helper.rb:56:in `current_controller'
~/.rvm/gems/ruby-2.0.0-p247/bundler/gems/nav_lynx-00ae77191c47/app/helpers/nav_link_helper.rb:72:in `current_segment'
~/.rvm/gems/ruby-2.0.0-p247/bundler/gems/nav_lynx-00ae77191c47/app/helpers/nav_link_helper.rb:80:in `segments_match?'
~/.rvm/gems/ruby-2.0.0-p247/bundler/gems/nav_lynx-00ae77191c47/app/helpers/nav_link_helper.rb:84:in `selected?'
~/.rvm/gems/ruby-2.0.0-p247/bundler/gems/nav_lynx-00ae77191c47/app/helpers/nav_link_helper.rb:100:in `html_options'
~/.rvm/gems/ruby-2.0.0-p247/bundler/gems/nav_lynx-00ae77191c47/app/helpers/nav_link_helper.rb:104:in `link'
~/.rvm/gems/ruby-2.0.0-p247/bundler/gems/nav_lynx-00ae77191c47/app/helpers/nav_link_helper.rb:24:in `to_html'
~/.rvm/gems/ruby-2.0.0-p247/bundler/gems/nav_lynx-00ae77191c47/app/helpers/nav_link_helper.rb:9:in `nav_link_to'
app/views/layouts/application.html.erb:21:in `_app_views_layouts_application_html_erb___1367320803645324380_70352220477360'
actionpack (4.0.0) lib/action_view/template.rb:143:in `block in render'
activesupport (4.0.0) lib/active_support/notifications.rb:161:in `instrument'
actionpack (4.0.0) lib/action_view/template.rb:141:in `render'
actionpack (4.0.0) lib/action_view/renderer/template_renderer.rb:61:in `render_with_layout'
actionpack (4.0.0) lib/action_view/renderer/template_renderer.rb:47:in `render_template'
actionpack (4.0.0) lib/action_view/renderer/template_renderer.rb:17:in `render'
actionpack (4.0.0) lib/action_view/renderer/renderer.rb:42:in `render_template'
actionpack (4.0.0) lib/action_view/renderer/renderer.rb:23:in `render'
actionpack (4.0.0) lib/abstract_controller/rendering.rb:127:in `_render_template'
actionpack (4.0.0) lib/action_controller/metal/streaming.rb:219:in `_render_template'
actionpack (4.0.0) lib/abstract_controller/rendering.rb:120:in `render_to_body'
actionpack (4.0.0) lib/action_controller/metal/rendering.rb:33:in `render_to_body'
actionpack (4.0.0) lib/action_controller/metal/renderers.rb:26:in `render_to_body'
actionpack (4.0.0) lib/abstract_controller/rendering.rb:97:in `render'
actionpack (4.0.0) lib/action_controller/metal/rendering.rb:16:in `render'
actionpack (4.0.0) lib/action_controller/metal/instrumentation.rb:41:in `block (2 levels) in render'
activesupport (4.0.0) lib/active_support/core_ext/benchmark.rb:12:in `block in ms'
~/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/benchmark.rb:296:in `realtime'
```
