### PR TITLE
Removing blank space when no specified wrapper_class

### DIFF
--- a/app/helpers/nav_link_helper.rb
+++ b/app/helpers/nav_link_helper.rb
@@ -129,6 +129,7 @@ module NavLinkHelper
 
     def wrapper_classes
       if selected?
+        return selected_class if @options[:wrapper_class].blank?
         "#{selected_class} #{@options[:wrapper_class]}"
       else
         @options[:wrapper_class]

--- a/spec/helpers/nav_link_helper_spec.rb
+++ b/spec/helpers/nav_link_helper_spec.rb
@@ -86,6 +86,12 @@ describe NavLinkHelper do
           .should == '<li class="container"><a href="/projects">Hi</a></li>'
       end
 
+      it "provides a class for the selected wrapper when specified" do
+        request.stub(:fullpath).and_return('/projects')
+        subject.new(request, 'Hi', '/projects', controller, {}, {:wrapper => 'li', :selected_class => 'special-selected'}).to_html
+          .should == '<li class="special-selected"><a href="/projects">Hi</a></li>'
+      end
+
       it "provides a class for the wrapper when specified along with a selected class if neeeded" do
         request.stub(:fullpath).and_return('/projects')
         subject.new(request, 'Hi', '/projects', controller, {}, {:wrapper => 'li', :wrapper_class => 'container'}).to_html


### PR DESCRIPTION
This is a small thing. When When no specified wrapper_class, the output was <li class="special-selected "><a href="/projects">Hi</a></li>, a blank space after li class name.
